### PR TITLE
Feature: Adds persistence layer for meetings and a retry option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 
 # Files containing credeentials
 envs.sh
+env.sh
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# DB Files
+*.db

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}/mattermost-bagel",
+            "env": {},
+            "args": []
+        }
+    ]
+}

--- a/config/persistence.go
+++ b/config/persistence.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/RobotDisco/mattermost-bagel/mattermost"
+	_ "github.com/mattn/go-sqlite3" // Add SQLite support
+)
+
+const (
+	// DefaultStaleBoundary is fallback value if the BAGEL_SQLITE_STALE_BOUNDARY environment variable is empty (default is 35 days)
+	DefaultStaleBoundary = "35 days"
+)
+
+// CreatePersistenceConfig ... TODO: (TL) Comment
+func CreatePersistenceConfig() PersistenceConfig {
+	if strings.ToLower(os.Getenv("BAGEL_PERSISTENCE_METHOD")) != "sqlite" {
+		return PersistenceConfig{}
+	}
+
+	// SQLite DB File
+	sqliteFile := os.Getenv("BAGEL_SQLITE_FILE")
+	if sqliteFile == "" {
+		// TODO: (TL) Fall back to a DB name?
+		fmt.Printf("'BAGEL_PERSISTENCE_METHOD' of 'sqlite' specified, but 'BAGEL_SQLITE_FILE' is not specified.\nFalling back to no persistence model.\n")
+		return PersistenceConfig{}
+	}
+
+	// SQLite DB
+	database, err := sql.Open("sqlite3", sqliteFile)
+	if err != nil {
+		fmt.Printf("Encountered error connecting to SQLite DB: %+v\nFalling back to 'PersistenceMethodNone'.\n", err)
+		return PersistenceConfig{}
+	}
+
+	// SQLite Create Table - see client.go for a sample GetChannelMembers call result TL;DR: ChannelId is a hash-type string, UserId is a hash-type string
+	// the 'pairing' column will be a concatenation of two `UserId` fields delimited by a colon, i.e. "3eizzrqatin3te8s3a3yj5r6xc:3eizzrqatin3te8s3a3yj5r6xd"
+	createTableStatement, err := database.Prepare("CREATE TABLE IF NOT EXISTS scheduled_outings (message_date INTEGER DEFAULT CURRENT_TIMESTAMP, channel_id TEXT, pairing TEXT)")
+	if err != nil {
+		fmt.Printf("Encountered error preparing CREATE TABLE statement: %+v\nFalling back to 'PersistenceMethodNone'.\n", err)
+		return PersistenceConfig{}
+	}
+	createTableStatement.Exec()
+
+	// SQLite INSERT statement
+	insertMeetupStatement, err := database.Prepare("INSERT INTO scheduled_outings (channel_id, pairing) VALUES (?, ?)")
+	if err != nil {
+		fmt.Printf("Encountered error preparing INSERT statement: %+v\nFalling back to 'PersistenceMethodNone'.\n", err)
+		return PersistenceConfig{}
+	}
+
+	// SQLite SELECT statement
+	timeframe := os.Getenv("BAGEL_SQLITE_STALE_BOUNDARY")
+	if timeframe == "" {
+		// Fall back to default 5 weeks
+		fmt.Printf("No value specified in 'BAGEL_SQLITE_STALE_BOUNDARY', falling back to %s.\n", DefaultStaleBoundary)
+		timeframe = DefaultStaleBoundary
+	}
+	// Find all outings that were previously scheduled between now and <timeframe> for the given channel and pair of users
+	selectMeetupsStatement := fmt.Sprintf("SELECT COUNT(1) FROM scheduled_outings WHERE message_date > datetime('now', '-%s') AND pairing = ?", timeframe)
+
+	retryCount := 1
+	retryEnvironmentVar := os.Getenv("BAGEL_PERSISTENCE_RETRY_COUNT")
+	if retryEnvironmentVar != "" {
+		retryCount, _ = strconv.Atoi(retryEnvironmentVar)
+	}
+
+	return PersistenceConfig{
+		PersistenceSQLite,
+		retryCount,
+		SQLiteClient{
+			database,
+			insertMeetupStatement,
+			selectMeetupsStatement,
+		},
+	}
+}
+
+// VerifyPairs uses the active PersistenceConfig to determine if matches have been previously made.
+// When using the PersistenceNone option, this is a simple passthrough.
+func (persistenceConfig PersistenceConfig) VerifyPairs(pairs mattermost.ChannelMemberPairs) VerifyResult {
+	if persistenceConfig.PersistenceType == PersistenceNone {
+		return VerifyResult{
+			Successes: pairs,
+		}
+	}
+	var successes mattermost.ChannelMemberPairs
+	var failures mattermost.ChannelMemberPairs
+	for _, pair := range pairs {
+		pairIdentifier := pair.Identifier()
+		fmt.Print(persistenceConfig.sqliteClient.selectMeetupsStatement)
+		fmt.Printf(" [%s]\n", pairIdentifier)
+		rows, err := persistenceConfig.sqliteClient.database.Query(persistenceConfig.sqliteClient.selectMeetupsStatement, pairIdentifier)
+		defer rows.Close()
+		if err != nil {
+			fmt.Printf("Encountered error with SELECT query: %+v, assuming failure.\n", err)
+			failures = append(failures, pair)
+		} else if rows.Next() { // Only expect one row
+			var previousPairingsWithinDateRange int
+			rows.Scan(&previousPairingsWithinDateRange)
+			if previousPairingsWithinDateRange == 0 { // Success, no records found!
+				fmt.Printf("No record exists, marking as a successful pair: %s\n", pair.Identifier())
+				successes = append(successes, pair)
+			} else { // Failure, try again!
+				fmt.Printf("A record exists for this pair: %s, storing as a leftover.\n", pair.Identifier())
+				failures = append(failures, pair)
+			}
+		} else {
+			fmt.Printf("A record exists for this pair: %s, storing as a leftover (%+v).\n", pair.Identifier(), err)
+			failures = append(failures, pair)
+		}
+	}
+	return VerifyResult{
+		successes,
+		failures,
+	}
+}
+
+// LogPairs considers the PersistenceType and outputs the pairs as appropriate (console, SQLite, etc.)
+func (persistenceConfig PersistenceConfig) LogPairs(pairs mattermost.ChannelMemberPairs) {
+	switch persistenceConfig.PersistenceType {
+	case PersistenceNone:
+		persistenceConfig.logPairsToConsole(pairs)
+	case PersistenceSQLite:
+		persistenceConfig.logPairsToSQLite(pairs)
+	}
+}
+
+func (persistenceConfig PersistenceConfig) logPairsToConsole(pairs mattermost.ChannelMemberPairs) {
+	for index, pair := range pairs {
+		pairIdentifier := pair.Identifier()
+		fmt.Printf("Pair #%d: %s\n", index, pairIdentifier)
+	}
+
+}
+
+func (persistenceConfig PersistenceConfig) logPairsToSQLite(pairs mattermost.ChannelMemberPairs) {
+	for _, pair := range pairs {
+		pairIdentifier := pair.Identifier()
+		_, err := persistenceConfig.sqliteClient.insertMeetupStatement.Exec(pair.ChannelID, pairIdentifier)
+		if err != nil {
+			fmt.Printf("Encountered error saving pair: %s (%+v).\n", pair.Identifier(), err)
+		}
+	}
+
+}

--- a/config/persistence_types.go
+++ b/config/persistence_types.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"database/sql"
+
+	"github.com/RobotDisco/mattermost-bagel/mattermost"
+)
+
+// PersistenceConfig represents the environment variables
+// used to configure the persistence portion of Bagel
+//
+// Expected environment variables:
+// - BAGEL_PERSISTENCE_METHOD (Options: "none", "sqlite")
+// - BAGEL_PERSISTENCE_RETRY_COUNT (Defaults to 0 for "none", 1 for everything else)
+//
+// SQLite Only
+// - BAGEL_SQLITE_FILE (Local path to the file)
+type PersistenceConfig struct {
+	PersistenceType PersistenceMethod
+	RetryCount      int
+	sqliteClient    SQLiteClient
+}
+
+// PersistenceMethod is an enum mapping the various persistence storage types available
+type PersistenceMethod int
+
+const (
+	// PersistenceNone specifies that no persistence will be used
+	PersistenceNone PersistenceMethod = 0
+	// PersistenceSQLite specifies that a local SQLite file DB is used
+	PersistenceSQLite PersistenceMethod = 1
+)
+
+// TODO: (TL) Add functions to the SQLiteClient so we're not manipulating raw stuffs
+
+// SQLiteClient wraps up the various pieces needed to SQLite db manipulation
+type SQLiteClient struct {
+	database               *sql.DB
+	insertMeetupStatement  *sql.Stmt
+	selectMeetupsStatement string
+}
+
+// VerifyResult ... TODO: (TL) Comment
+type VerifyResult struct {
+	Successes mattermost.ChannelMemberPairs
+	Failures  mattermost.ChannelMemberPairs
+}

--- a/config/persistence_types_test.go
+++ b/config/persistence_types_test.go
@@ -1,0 +1,17 @@
+package config_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/RobotDisco/mattermost-bagel/config"
+)
+
+func TestSQLitePersistenceConfig(t *testing.T) {
+	fmt.Println("TestSQLitePersistenceConfig") // TODO: (TL) Doesn't find environment variables
+	persistenceConfig := config.CreatePersistenceConfig()
+	if persistenceConfig.PersistenceType == config.PersistenceNone {
+		t.Errorf("SQLite was not configured!")
+	}
+	// TODO: (TL) Test DB with a test database file
+}

--- a/config/types.go
+++ b/config/types.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+)
+
+// BagelConfig contains the environment variables needed
+// to connect to a mattermost server and team
+// as a specified user, in a given channel
+//
+// Expected environment variables:
+// - BAGEL_MATTERMOST_URL
+// - BAGEL_USERNAME
+// - BAGEL_PASSWORD
+// - BAGEL_TEAM_NAME
+// - BAGEL_CHANNEL_NAME
+type BagelConfig struct {
+	ServerURL   string
+	BotUserName string
+	BotPassword string
+	TeamName    string
+	ChannelName string
+}
+
+// CreateBagelConfig loads the required environment variables and creates
+// a BagelConfig object encapsulating those values
+func CreateBagelConfig() BagelConfig {
+	return BagelConfig{
+		ServerURL:   os.Getenv("BAGEL_MATTERMOST_URL"),
+		BotUserName: os.Getenv("BAGEL_USERNAME"),
+		BotPassword: os.Getenv("BAGEL_PASSWORD"),
+		TeamName:    os.Getenv("BAGEL_TEAM_NAME"),
+		ChannelName: os.Getenv("BAGEL_CHANNEL_NAME"),
+	}
+}

--- a/env.sh.template
+++ b/env.sh.template
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export BAGEL_MATTERMOST_URL="https://mattermost.url"
+export BAGEL_USERNAME="username"
+export BAGEL_PASSWORD="password"
+export BAGEL_TEAM_NAME="general"
+export BAGEL_CHANNEL_NAME="channel"
+
+# Options: "none", "sqlite"
+export BAGEL_PERSISTENCE_METHOD="none"
+export BAGEL_PERSISTENCE_RETRY_COUNT=0
+
+# sqlite specific
+export BAGEL_SQLITE_FILE="./bagel-sqlite.db"
+export BAGEL_SQLITE_STALE_BOUNDARY="35 days"

--- a/main.go
+++ b/main.go
@@ -2,27 +2,80 @@ package main
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/RobotDisco/mattermost-bagel/config"
 	"github.com/RobotDisco/mattermost-bagel/mattermost"
+	"github.com/mattermost/mattermost-server/model"
+)
+
+const (
+	// DefaultPairingMessage is when we were able to pair two new folks together
+	DefaultPairingMessage = "Hello! This week you have been matched up as conversation partners! I hope you meet up and have a great time :)"
+	// ConsolingPairingMessage says we tried our best but failed miserably, the lesson learned was to never try!
+	ConsolingPairingMessage = "Hello! This week you have been matched up as conversation partners again! Maybe you can continue the conversation from last time? Have a great time :)"
 )
 
 func main() {
-	serverURL := os.Getenv("BAGEL_MATTERMOST_URL")
+	bagelConfig := config.CreateBagelConfig()
+	persistenceConfig := config.CreatePersistenceConfig()
+	matchAndSchedulePairs(bagelConfig, persistenceConfig)
+}
 
-	botUserName := os.Getenv("BAGEL_USERNAME")
-	botPassword := os.Getenv("BAGEL_PASSWORD")
+func matchAndSchedulePairs(bagelConfig config.BagelConfig, persistenceConfig config.PersistenceConfig) {
+	api := mattermost.NewMatterMostClient(bagelConfig.ServerURL, bagelConfig.BotUserName, bagelConfig.BotPassword)
 
-	teamName := os.Getenv("BAGEL_TEAM_NAME")
-	channelName := os.Getenv("BAGEL_CHANNEL_NAME")
-
-	api := mattermost.NewMatterMostClient(serverURL, botUserName, botPassword)
-
-	members := mattermost.GetActiveChannelMembers(*api, teamName, channelName)
-	fmt.Printf("%+v\n", members)
-	fmt.Printf("There are %d members in channel %s for team %s\n", len(members), channelName, teamName)
+	channelID, members := mattermost.GetActiveChannelMembers(*api, bagelConfig.TeamName, bagelConfig.ChannelName)
+	fmt.Printf("There are %d members in channel %s for team %s\n", len(members), bagelConfig.ChannelName, bagelConfig.TeamName)
 	bot := mattermost.GetBotUser(*api)
-	pairs := mattermost.SplitIntoPairs(members, bot.Id)
+	pairs := mattermost.SplitIntoPairs(channelID, members, bot.Id)
+	fmt.Printf("Created %d pair(s)\n", len(pairs))
 
-	mattermost.MessageMembers(*api, pairs, bot)
+	verifyResult := persistenceConfig.VerifyPairs(pairs)
+	persistenceConfig.LogPairs(verifyResult.Successes)
+	mattermost.MessageMembers(*api, verifyResult.Successes, bot, DefaultPairingMessage)
+	failingPairCount := len(verifyResult.Failures)
+
+	if failingPairCount == 0 {
+		fmt.Println("Scheduling completed with no duplications!")
+		return
+	}
+	if failingPairCount == 1 {
+		fmt.Println("1 pair will have to continue the conversation from last time, sorry!")
+		persistenceConfig.LogPairs(verifyResult.Failures)
+		mattermost.MessageMembers(*api, verifyResult.Failures, bot, ConsolingPairingMessage)
+		return
+	}
+	if persistenceConfig.RetryCount == 0 {
+		if failingPairCount > 0 {
+			fmt.Printf("%d pair(s) will have to continue the conversation from last time, sorry!\n", len(verifyResult.Failures))
+			persistenceConfig.LogPairs(verifyResult.Failures)
+			mattermost.MessageMembers(*api, verifyResult.Failures, bot, ConsolingPairingMessage)
+		}
+		return
+	}
+
+	fmt.Printf("%d pairs have been mached previously, retrying.\n", failingPairCount)
+	retryScheduling(api, bot, persistenceConfig, verifyResult.Failures)
+}
+
+func retryScheduling(api *model.Client4, bot *model.User, persistenceConfig config.PersistenceConfig, failedPairs mattermost.ChannelMemberPairs) {
+	persistenceConfig.RetryCount--
+	retryPairs := mattermost.RetryPairs(failedPairs)
+	retryVerifyResult := persistenceConfig.VerifyPairs(retryPairs)
+	persistenceConfig.LogPairs(retryVerifyResult.Successes)
+	fmt.Printf("Re-pairing created %d previously unmatched pairs.\n", len(retryVerifyResult.Successes))
+	mattermost.MessageMembers(*api, retryVerifyResult.Successes, bot, DefaultPairingMessage)
+
+	retryFailureCount := len(retryVerifyResult.Failures)
+	if retryFailureCount == 0 { // Successfully handled all failures!
+		return
+	}
+	// We can't try again if we've reached the limit or have one pair left, log and avoid retrying
+	if persistenceConfig.RetryCount == 0 || retryFailureCount == 1 {
+		fmt.Printf("%d pair(s) will have to continue the conversation from last time, sorry!\n", retryFailureCount)
+		persistenceConfig.LogPairs(retryVerifyResult.Failures)
+		mattermost.MessageMembers(*api, retryVerifyResult.Failures, bot, ConsolingPairingMessage)
+	} else {
+		retryScheduling(api, bot, persistenceConfig, retryVerifyResult.Failures)
+	}
 }

--- a/mattermost/client.go
+++ b/mattermost/client.go
@@ -20,29 +20,29 @@ func NewMatterMostClient(url string, username string, password string) *model.Cl
 }
 
 // GetActiveChannelMembers retrieves a list of active members in a given channel for the specified teamName
-func GetActiveChannelMembers(m model.Client4, teamName string, channelName string) model.UserSlice {
+func GetActiveChannelMembers(m model.Client4, teamName string, channelName string) (string, model.UserSlice) {
 	team, resp := m.GetTeamByName(teamName, "")
 	if resp.Error != nil {
-		fmt.Fprintf(os.Stderr, "Error: %+v", resp)
+		fmt.Fprintf(os.Stderr, "Error: %+v\n", resp)
 		os.Exit(1)
 	}
 	//fmt.Printf("%+v\n", team)
 
 	channel, resp := m.GetChannelByName(channelName, team.Id, "")
 	if resp.Error != nil {
-		fmt.Fprintf(os.Stderr, "Error: %+v", resp)
+		fmt.Fprintf(os.Stderr, "Error: %+v\n", resp)
 		os.Exit(1)
 	}
 	//fmt.Printf("%+v\n", channel)
 
 	members, resp := m.GetUsersInChannel(channel.Id, 0, 100, "")
 	if resp.Error != nil {
-		fmt.Fprintf(os.Stderr, "Error: %+v", resp)
+		fmt.Fprintf(os.Stderr, "Error: %+v\n", resp)
 		os.Exit(1)
 	}
 
 	slice := model.UserSlice(members)
-	return slice.FilterByActive(true)
+	return channel.Id, slice.FilterByActive(true)
 }
 
 /* GetChannelMembers call result
@@ -76,7 +76,7 @@ func GetActiveChannelMembers(m model.Client4, teamName string, channelName strin
 func GetBotUser(m model.Client4) *model.User {
 	user, resp := m.GetMe("")
 	if resp.Error != nil {
-		fmt.Fprintf(os.Stderr, "Error: %+v", resp)
+		fmt.Fprintf(os.Stderr, "Error: %+v\n", resp)
 		os.Exit(1)
 	}
 
@@ -84,22 +84,23 @@ func GetBotUser(m model.Client4) *model.User {
 }
 
 // MessageMembers sends a message via mattermost to each set of pairs
-func MessageMembers(m model.Client4, pairs ChannelMemberPairs, botUser *model.User) {
+func MessageMembers(m model.Client4, pairs ChannelMemberPairs, botUser *model.User, message string) {
+	fmt.Printf("Messaging %d pairs\n", len(pairs))
 	for _, p := range pairs {
 		uidList := []string{p.First.Id, p.Second.Id, botUser.Id}
 		channel, resp := m.CreateGroupChannel(uidList)
 
-		fmt.Printf("Channel: %v", channel)
-		fmt.Printf("Received response: %v", resp)
+		fmt.Printf("Channel: %v\n", channel)
+		fmt.Printf("Received response: %v\n", resp)
 
 		post := &model.Post{
 			ChannelId: channel.Id,
 			UserId:    botUser.Id,
-			Message:   "Hello! This week you have been matched up as conversation partners! I hope you meet up and have a great time :)",
+			Message:   message,
 		}
 		_, resp = m.CreatePost(post)
 		if resp.Error != nil {
-			fmt.Fprintf(os.Stderr, "Error: %+v", resp)
+			fmt.Fprintf(os.Stderr, "Error: %+v\n", resp)
 			os.Exit(1)
 		}
 	}

--- a/mattermost/client_test.go
+++ b/mattermost/client_test.go
@@ -49,7 +49,7 @@ func TestGetActiveChannelMembers(t *testing.T) {
 	channelName := os.Getenv("BAGEL_CHANNEL_NAME")
 
 	api := NewMatterMostClient(serverURL, botUserName, botPassword)
-	members := GetActiveChannelMembers(*api, teamName, channelName)
+	_, members := GetActiveChannelMembers(*api, teamName, channelName)
 
 	for _, m := range members {
 		if m.DeleteAt != 0 {

--- a/mattermost/matcher_test.go
+++ b/mattermost/matcher_test.go
@@ -18,12 +18,12 @@ func TestNumberOfPairs(t *testing.T) {
 
 	api := NewMatterMostClient(serverURL, botUserName, botPassword)
 
-	members := GetActiveChannelMembers(*api, teamName, channelName)
+	channelID, members := GetActiveChannelMembers(*api, teamName, channelName)
 	bot := GetBotUser(*api)
 
 	memberCount := len(members) - 1
 
-	pairs := SplitIntoPairs(members, bot.Id)
+	pairs := SplitIntoPairs(channelID, members, bot.Id)
 	pairCount := len(pairs)
 	if pairCount != (memberCount / 2) {
 		t.Errorf("Expected %d; Actual %d\nMembers: %v\nPairs: %v\n", memberCount/2, pairCount, members, pairs)


### PR DESCRIPTION
  - Added BAGEL_PERSISTENCE_METHOD ("none", or "sqlite")
  - Added BAGEL_PERSISTENCE_RETRY_COUNT to control how many retries are executed for previously matched pairs (requires persistence of "sqlite"
  - Added BAGEL_SQLITE_FILE to specify the DB file

Refactor: Separated types into separate files
  - Created BagelConfig type
  - Created PersistenceConfig type